### PR TITLE
Fix test failures and export calculate_rif

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
+*.json
+# Athey & Imbens original MATLAB replication code and local development files
+Other/

--- a/src/QuantileEffects.jl
+++ b/src/QuantileEffects.jl
@@ -790,6 +790,7 @@ function cic(df,
     return data
 end
 export cic
+export calculate_rif
 ####Now add the RIF part
 
 function calculate_rif(df,outcome_var, quantile_value)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,9 @@ test_rif=calculate_rif(df,outcome,0.5)
      # 4) No NaN/Inf and correct dimensions
     for key in ["est","boot_est","se","se_boot"]
         arr = result[key]
-        arr_vec = [ x for mat in arr for x in mat ]
+        # "est" and "se" are Vector{Matrix}, so iterate mat→elements.
+        # "boot_est" (3-D) and "se_boot" (2-D) are plain numeric arrays; just flatten.
+        arr_vec = arr isa AbstractVector ? [x for mat in arr for x in mat] : vec(arr)
         @testset "checking $key" begin
             # a) all entries finite (no NaN, no Inf)
             @test all(isfinite, arr_vec)


### PR DESCRIPTION
- Export calculate_rif so tests can call it after `using QuantileEffects`
- Fix arr_vec iteration crash for boot_est (3D) and se_boot (2D) arrays: the old loop assumed all result values were Vector{Matrix}, but those two are plain numeric arrays; use vec() for them instead
- Gitignore *.json (cic() writes output files) and Other/ (MATLAB source)